### PR TITLE
🚇 Exclude exercise notebooks from CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,14 +38,21 @@ jobs:
           import json
           from pathlib import Path
 
+          block_list =[
+              "BRC_NIR-global-case-study-pretty",
+              "BRC_VIS_NIR-target-case-study-pretty",
+              "BRC_VIS-global-case-study-pretty",
+          ]
+
           notebook_paths = []
           for notebook_path in Path().rglob("*.ipynb"):
-              notebook_paths.append(
-                  {
-                      "name": notebook_path.stem,
-                      "path": notebook_path.resolve().as_posix(),
-                  }
-              )
+              if notebook_path.stem not in block_list:
+                  notebook_paths.append(
+                      {
+                          "name": notebook_path.stem,
+                          "path": notebook_path.resolve().as_posix(),
+                      }
+                  )
 
           print(f"::set-output name=notebook-list::{json.dumps(notebook_paths)}")
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,6 +42,7 @@ jobs:
               "BRC_NIR-global-case-study-pretty",
               "BRC_VIS_NIR-target-case-study-pretty",
               "BRC_VIS-global-case-study-pretty",
+              "CK-case-study",
           ]
 
           notebook_paths = []

--- a/README.md
+++ b/README.md
@@ -13,3 +13,7 @@ in preparation
 - [PAL](./PAL-case-study/)
 - [PCP](./PCP-case-study/)
 - [Spirulina](./Spirulina-case-study/)
+
+## Exercises
+
+- [BRC](./BRC-case-study/)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ in preparation
 ## Case studies
 
 - [BE](./BE-case-study/)
-- [CK](./CK-case-study/)
 - [PAL](./PAL-case-study/)
 - [PCP](./PCP-case-study/)
 - [Spirulina](./Spirulina-case-study/)
@@ -17,3 +16,4 @@ in preparation
 ## Exercises
 
 - [BRC](./BRC-case-study/)
+- [CK](./CK-case-study/)


### PR DESCRIPTION
This fixes the CI tests failing on the exercise notebooks since they are technically broken models due to missing parameter values in the parameter files which students are supposed to fill in.