### PR TITLE
✨ Added show_a_matrix to oc_coc_tol-case-study

### DIFF
--- a/oc_coc_tol-case-study/coc_tol.ipynb
+++ b/oc_coc_tol-case-study/coc_tol.ipynb
@@ -161,6 +161,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from show_a_matrix import show_a_matrix\n",
+    "\n",
+    "show_a_matrix(coc_tol_global_result)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -230,7 +241,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##First Target Analysis: small triplet yield"
+    "## First Target Analysis: small triplet yield"
    ]
   },
   {
@@ -406,11 +417,20 @@
     "    \"0.0000e+00\", \"\"\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_a_matrix(coc_tol_target_result)"
+   ]
   }
  ],
  "metadata": {
   "interpreter": {
-   "hash": "a21d58caabd9076bb5b46436ba653e0c3388531d8605b268fe4bb047e3acee81"
+   "hash": "3731ce72dbd91e4f192785b744e81c0f8b70f4bed0bf93b29715722e6acba1b3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/oc_coc_tol-case-study/oc_coc_tol_target.ipynb
+++ b/oc_coc_tol-case-study/oc_coc_tol_target.ipynb
@@ -267,11 +267,22 @@
     "    \"0.0000e+00\", \"\"\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from show_a_matrix import show_a_matrix\n",
+    "\n",
+    "show_a_matrix(oc_coc_tol_target_result)"
+   ]
   }
  ],
  "metadata": {
   "interpreter": {
-   "hash": "a21d58caabd9076bb5b46436ba653e0c3388531d8605b268fe4bb047e3acee81"
+   "hash": "3731ce72dbd91e4f192785b744e81c0f8b70f4bed0bf93b29715722e6acba1b3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/oc_coc_tol-case-study/oc_tol.ipynb
+++ b/oc_coc_tol-case-study/oc_tol.ipynb
@@ -161,6 +161,17 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from show_a_matrix import show_a_matrix\n",
+    "\n",
+    "show_a_matrix(oc_tol_global_result)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -228,7 +239,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##First Target Analysis: small triplet yield"
+    "## First Target Analysis: small triplet yield"
    ]
   },
   {
@@ -404,11 +415,20 @@
     "    \"0.0000e+00\", \"\"\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_a_matrix(oc_tol_target_result)"
+   ]
   }
  ],
  "metadata": {
   "interpreter": {
-   "hash": "a21d58caabd9076bb5b46436ba653e0c3388531d8605b268fe4bb047e3acee81"
+   "hash": "3731ce72dbd91e4f192785b744e81c0f8b70f4bed0bf93b29715722e6acba1b3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/oc_coc_tol-case-study/show_a_matrix.py
+++ b/oc_coc_tol-case-study/show_a_matrix.py
@@ -1,0 +1,55 @@
+"""Quick and dirty implementation to show all a-matrixes of a result."""
+
+from __future__ import annotations
+
+from glotaran.project import Result
+from glotaran.utils.ipython import MarkdownStr
+from tabulate import tabulate
+
+
+def show_a_matrix(result: Result, heading_offset: int = 2) -> MarkdownStr:
+    """Return a markdownstr showing all a-matrixes of the result split by name and dataset."""
+    heading_prefix = heading_offset * "#"
+    output_str = f"#{heading_prefix} A-Matrixes"
+
+    for dataset_name in result.data:
+
+        output_str += f"\n\n##{heading_prefix} {dataset_name}:\n"
+
+        a_matrix_names = list(
+            filter(
+                lambda var_name: var_name.startswith("a_matrix_"),
+                result.data[dataset_name].data_vars,
+            )
+        )
+
+        for a_matrix_name in a_matrix_names:
+
+            a_matrix = result.data[dataset_name][a_matrix_name]
+
+            mc_suffix = a_matrix_name.replace("a_matrix_", "")
+
+            header = ["species<br>initial concentration<br>lifetime↓"] + [
+                f"{sp}<br>{ic}<br>&nbsp;"
+                for sp, ic in zip(
+                    a_matrix.coords[f"species_{mc_suffix}"].values,
+                    a_matrix.coords[f"initial_concentration_{mc_suffix}"].values,
+                )
+            ]
+
+            data = [
+                [lifetime, *amps]
+                for lifetime, amps in zip(
+                    a_matrix.coords[f"lifetime_{mc_suffix}"].values, a_matrix.values
+                )
+            ]
+
+            output_str += f"\n\n###{heading_prefix} {a_matrix_name}:\n\n"
+
+            output_str += (
+                tabulate(data, headers=header, showindex=False, tablefmt="unsafehtml")
+                .replace(" 0 ", "   ")
+                .replace(" 0<", "  <")
+            )
+
+    return MarkdownStr(output_str)


### PR DESCRIPTION
This adds the functionality to show all a-matrixes for a given result.
The output looks like this:
![image](https://user-images.githubusercontent.com/9513634/170113513-4ef65e4a-2ce7-46b0-847c-78b2b3496082.png)

This is only a quick fix for missing functionality and should be removed when this feature is implemented in pyglotaran or the pyglotaran extras.